### PR TITLE
Remove broken link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,4 @@ Here is a link that works well: [Wikipedia](https://www.wikipedia.org/)
 
 Here is a link that works well if you set the user agent: [https://forum.image.sc/](https://forum.image.sc/)
 
-Here is a link that doesn't work well: [This page does not exist!](https://dask.org/this-link-does-not-exist)
-
 Thanks for testing!


### PR DESCRIPTION
I want to see whether the lychee report opens an issue if all the links are good, or only if problems are found.